### PR TITLE
Added TestCase for Nullpointer exception

### DIFF
--- a/java/client/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
+++ b/java/client/test/org/openqa/selenium/remote/RemoteWebDriverUnitTest.java
@@ -1065,7 +1065,12 @@ public class RemoteWebDriverUnitTest {
         new CommandPayload(DriverCommand.GET_ELEMENT_VALUE_OF_CSS_PROPERTY,
                            ImmutableMap.of("id", element.getId(), "propertyName", "color")));
   }
-
+  
+  @Test
+  public void noArgConstuctorEmptyCapabilitiesTest() throws IOException {
+    RemoteWebDriver driver = new RemoteWebDriver();
+    assertThat(driver.getCapabilities()).isNotNull();
+  }
   private class MultiCommandPayload extends CommandPayload {
     private int times;
 


### PR DESCRIPTION
Test case to ensure capabilities initialize to empty when no arg constructor called. If not initialized then it will throw null pointer exception when executeScript() or isJavascriptEnabled() method called